### PR TITLE
Removing unecessary includes from setup.py. They were causing errors.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ config = {
 	'download_url': '',
 	'author_email': 'elmer.thomas@sendgrid.com',
 	'version': '0.1',
-	'install_requires': ['nose', 'zipfile', 'sys', 'os', 'os.path', 'Flask', 'Flask-SQLAlchemy', 'Jinja2', 'Werkzeug', 'distribute', 'wsgiref', 'mysql-python', 'requests', 'simplejson', 'configobj', 'time'],
+	'install_requires': ['nose', 'Flask', 'Flask-SQLAlchemy', 'Jinja2', 'Werkzeug', 'distribute', 'wsgiref', 'mysql-python', 'requests', 'simplejson', 'configobj'],
 	'packages': ['dmarc_parser'],
 	'scripts': [],
 	'name': 'DMARC Parser'


### PR DESCRIPTION
Looks like these are part of python, and don't need to be pulled via setup.py

'zipfile', 'sys', 'os', 'os.path', 'time'
